### PR TITLE
Changed $fib variable name to $sequence, for better readability

### DIFF
--- a/fibonacci/botommUp.php
+++ b/fibonacci/botommUp.php
@@ -6,18 +6,18 @@ use brhmms\katas\Fibonacci;
 
 class BottomUp implements Fibonacci {
 
-    private $fib = array();
-    
+    private $sequence = array();
+
     public function fib(int $number) {
         for ($k = 1; $k <= $number; $k++) {
             if ($k <= 2) {
                 $f = 1;
             } else {
-                $f = $this->fib[$k - 1] + $this->fib[$k - 2];
+                $f = $this->sequence[$k - 1] + $this->sequence[$k - 2];
             }
-            $this->fib[$k] = $f;
+            $this->sequence[$k] = $f;
         }
-        return $this->fib[$number];
+        return $this->sequence[$number];
     }
 
 }


### PR DESCRIPTION
I think this variable name is better, because $this->fib and $this->fib could be used to use both the function name and variable name, it's a silly argument, but I have had some problems due to instance variables names that are equals to function names.

Regards!